### PR TITLE
feat: add tf mnist training sample launch config for vscode

### DIFF
--- a/examples/tensorflow/MNIST/.vscode/launch.json
+++ b/examples/tensorflow/MNIST/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    // 使用 IntelliSense 了解相关属性。 
+    // 悬停以查看现有属性的描述。
+    // 欲了解更多信息，请访问: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/mnist.py",
+            "args": [
+                "--input_dir ${workspaceFolder}/input/",
+                "--output_dir ${workspaceFolder}/output/"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Add this `launch.json` file to enable user could run the `tf/mnist` sample when pressing `F5`