### PR TITLE
Add Tensorboard Support for CNTK MNIST example: train_mnist_onnx.py

### DIFF
--- a/examples/cntk/python/MNIST/train_mnist_onnx.py
+++ b/examples/cntk/python/MNIST/train_mnist_onnx.py
@@ -201,7 +201,7 @@ def train_test(train_reader, test_reader, model_func, x, y, learning_rate, minib
     # Instantiate the Tensorboard writer
     tensorboard_writer = None
     if tensorboard_logdir is not None:
-        tensorboard_writer = TensorBoardProgressWriter(freq=10, log_dir="log_dir", model=model)
+        tensorboard_writer = TensorBoardProgressWriter(freq=10, log_dir=tensorboard_logdir, model=model)
     
     # Instantiate the loss and error function
     loss, label_error = create_criterion_function(model, y)
@@ -271,8 +271,7 @@ def main():
     parser.add_argument('--minibatch_size', type=int, default=64, help='minibatch size')
     parser.add_argument('--input_dir', help="Input directory where where training dataset and meta data are saved")
     parser.add_argument('--output_dir', help="Output directory where output such as logs are saved.")
-    parser.add_argument('--tensorboard_logdir', '--tensorboard_logdir',
-                        help='Directory where TensorBoard logs should be created', required=False, default=None)
+    parser.add_argument('--tensorboard_logdir', type=str, default=None, help="Directory where TensorBoard logs should be saved.")
     
     args = parser.parse_args()
 
@@ -307,7 +306,7 @@ def main():
     z = create_model(x, num_output_classes)
     reader_train = create_reader(train_file, True, input_dim, num_output_classes)
     reader_test = create_reader(test_file, False, input_dim, num_output_classes)
-    train_test(reader_train, reader_test, z, x, y, args.learning_rate, args.minibatch_size, args.tensorboard_logdir)
+    train_test(reader_train, reader_test, z, x, y, args.learning_rate, args.minibatch_size, tensorboard_logdir=args.tensorboard_logdir)
 
     z.save('mnist.onnx', format=C.ModelFormat.ONNX)
 


### PR DESCRIPTION
## What does this feature do?
This feature adds support for TensorBoard to the `train_mnist_onnx.py` example.

### Changes
#### imports
  + `from cntk.logging import TensorBoardProgressWriter`
#### main()
  + accepts an additional args argument, `--tensorboard_logdir`, which is a `str` with a default value of `None`.
  + The call to `train_test()` now passes in the value of `args.tensorboard_logdir` explicitly to the function.

#### train_test()
  + added new function paramater, `tensorboard_logdir`, which has a default of `None`.
  + sets up a `TensorBoardProgressWriter` object, with a progress update frequency of 10.
  + passes the writer object to the `Trainer`.

## Motivation
This is to address the issue/labeled enhancement from #99.

## Usage
Launch TensorBoard as you typically would from the script's directory. Specify a log directory to watch within the scope of that directory. For example, `tensorboard --logdir=log`, where `log` is arbitrary and is to be determined by you (unless you already have a log directory you wish to use).

Then you need to either configure VS to run with the script with the following argument: `--tensorboard_logdir log`, where `log` will be the same name as the directory you used in the step above.

When your script runs, you should expect to see loss curves and a graph displayed on TensorBoard for you to evaluate.

## How has this been tested?
 I've run this using multiple possible log directories (including none) to ensure that expected behavior is preserved. 

In the case that a log file is provided to the script, if the directory does not yet exist, CNTK creates it and outputs log files to it as expected.

In the case that no log file is specified, no directory is created and TensorBoard will not display any loss curves or a graph.

## Screenshots
![2018-10-10](https://user-images.githubusercontent.com/16039329/46776358-9851b680-cce1-11e8-893e-fea9fd549c00.png)

