### PR TITLE
cuda(async) —> cuda(non_blocking) for Python >= 3.7

### DIFF
--- a/examples/cntk/python/ptb/data_reader.py
+++ b/examples/cntk/python/ptb/data_reader.py
@@ -4,6 +4,8 @@
 # for full license information.
 # ==============================================================================
 
+import sys
+
 import cntk as C
 
 # Read the mapping of tokens to ids from a file (tab separated)

--- a/examples/keras/DenseNet/densenet.py
+++ b/examples/keras/DenseNet/densenet.py
@@ -304,7 +304,7 @@ def DenseNetFCN(input_shape, nb_dense_block=5, growth_rate=16, nb_layers_per_blo
     if input_shape is None:
         raise ValueError('For fully convolutional models, input shape must be supplied.')
 
-    if type(nb_layers_per_block) is not list and nb_dense_block < 1:
+    if not isinstance(nb_layers_per_block, list) and nb_dense_block < 1:
         raise ValueError('Number of dense layers per block must be greater than 1. Argument '
                          'value was %d.' % (nb_layers_per_block))
 
@@ -593,7 +593,7 @@ def __create_dense_net(nb_classes, img_input, include_top, depth=40, nb_dense_bl
         assert reduction <= 1.0 and reduction > 0.0, 'reduction value must lie between 0.0 and 1.0'
 
     # layers in each dense block
-    if type(nb_layers_per_block) is list or type(nb_layers_per_block) is tuple:
+    if isinstance(nb_layers_per_block, (list, tuple)):
         nb_layers = list(nb_layers_per_block)  # Convert tuple to list
 
         assert len(nb_layers) == (nb_dense_block), 'If list, nb_layer is used as provided. ' \
@@ -704,7 +704,7 @@ def __create_fcn_dense_net(nb_classes, img_input, include_top, nb_dense_block=5,
                                                                     'than 12'
 
     # layers in each dense block
-    if type(nb_layers_per_block) is list or type(nb_layers_per_block) is tuple:
+    if isinstance(nb_layers_per_block, (list, tuple)):
         nb_layers = list(nb_layers_per_block)  # Convert tuple to list
 
         assert len(nb_layers) == (nb_dense_block + 1), 'If list, nb_layer is used as provided. ' \

--- a/examples/pytorch/ScreenerNet/snet.py
+++ b/examples/pytorch/ScreenerNet/snet.py
@@ -37,7 +37,7 @@ def validate(val_loader, model, criterion, epoch):
     model.eval()
 
     for i, (images, target) in enumerate(train_loader):
-        target = target.cuda(async=True)
+        target = target.cuda(non_blocking=True)
         image_var=torch.autograd.Variable(images)
         label_var = torch.autograd.Variable(target)
 

--- a/examples/tensorflow/MemN2N/model.py
+++ b/examples/tensorflow/MemN2N/model.py
@@ -132,7 +132,7 @@ class MemN2N(object):
             bar = ProgressBar('Train', max=N)
 
         for idx in xrange(N):
-            if self.show: bar.next()
+            if self.show: next(bar)
             target.fill(0)
             for b in xrange(self.batch_size):
                 m = random.randrange(self.mem_size, len(data))
@@ -171,7 +171,7 @@ class MemN2N(object):
 
         m = self.mem_size
         for idx in xrange(N):
-            if self.show: bar.next()
+            if self.show: next(bar)
             target.fill(0)
             for b in xrange(self.batch_size):
                 target[b][data[m]] = 1

--- a/examples/tensorflow/NTM/ops.py
+++ b/examples/tensorflow/NTM/ops.py
@@ -75,7 +75,7 @@ def Linear(input_, output_size, stddev=0.5,
         output_size: the size of output matrix or vector
     """
     with tf.variable_scope("Linear", reuse=reuse):
-        if type(input_) == np.ndarray:
+        if isinstance(input_, np.ndarray):
             shape = input_.shape
         else:
             shape = input_.get_shape().as_list()

--- a/examples/tensorflow/NTM/tasks/recall.py
+++ b/examples/tensorflow/NTM/tasks/recall.py
@@ -4,6 +4,8 @@ import numpy as np
 import tensorflow as tf
 from random import randint
 
+from six.moves import xrange
+
 from ntm import NTM
 from utils import pprint
 from ntm_cell import NTMCell


### PR DESCRIPTION
__async__ is a reserved word in Python 3.7 and later.  To fix this pytorch/pytorch#4999 changed __cuda(async=True)__ to __cuda(non_blocking=True)__ so this PR tracks with that change which landed in PyTourch 0.4.1.

Also use __isinstance()__ instead of comparing types, __import sys__ and __from six.moves import xrange__.

[flake8](http://flake8.pycqa.org) testing of https://github.com/microsoft/samples-for-ai on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./examples/tensorflow/NTM/tasks/recall.py:64:5: F821 undefined name 'start_symbol'
    start_symbol[0] = 1
    ^
./examples/tensorflow/NTM/tasks/recall.py:66:5: F821 undefined name 'end_symbol'
    end_symbol[1] = 1
    ^
./examples/tensorflow/NTM/tasks/recall.py:73:16: F821 undefined name 'xrange'
    for idx in xrange(config.epoch):
               ^
./examples/tensorflow/NTM/tasks/recall.py:82:31: F821 undefined name 'start_symbol'
            ntm.start_symbol: start_symbol,
                              ^
./examples/tensorflow/NTM/tasks/recall.py:83:29: F821 undefined name 'end_symbol'
            ntm.end_symbol: end_symbol
                            ^
./examples/tensorflow/NTM/tasks/recall.py:102:16: F821 undefined name 'xrange'
    for idx in xrange(num_items):
               ^
./examples/cntk/python/ptb/data_reader.py:33:13: F821 undefined name 'sys'
            sys.exit()
            ^
./examples/cntk/python/ptb/data_reader.py:60:25: F821 undefined name 'sys'
                        sys.exit()
                        ^
./examples/pytorch/ScreenerNet/snet.py:40:34: E999 SyntaxError: invalid syntax
        target = target.cuda(async=True)
                                 ^
1     E999 SyntaxError: invalid syntax
8     F821 undefined name 'sys'
9
```

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
